### PR TITLE
Patch subscriptions

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -23,9 +23,16 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
   def update
-    subscription = Subscription.find(params[:subscription_id])
-    subscription.update(subscription_params)
-    render json: SubscriptionSerializer.new(subscription), status: 200
+    begin
+      subscription = Subscription.find(params[:subscription_id])
+      if subscription.update(subscription_params)
+        render json: SubscriptionSerializer.new(subscription), status: 200
+      else
+        render json: { error: subscription.errors.full_messages.to_sentence }, status: 400
+      end
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "Invalid Subscription ID" }, status: 400
+    end
   end
 
   private

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -22,6 +22,12 @@ class Api::V1::SubscriptionsController < ApplicationController
       end
   end
 
+  def update
+    subscription = Subscription.find(params[:subscription_id])
+    subscription.update(subscription_params)
+    render json: SubscriptionSerializer.new(subscription), status: 200
+  end
+
   private
     def subscription_params
       params.permit(:title, :price, :status, :frequency, :tea_id, :customer_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :customers do
-        resources :subscriptions, only: %i[index create destroy]
+        resources :subscriptions, only: %i[index create update]
       end
     end
   end

--- a/spec/requests/api/v1/update_request_spec.rb
+++ b/spec/requests/api/v1/update_request_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe 'Subscription PATCH Request' do
+  describe 'happy path' do
+    it "updates a subscription's status to 'cancelled'"do
+      Customer.destroy_all
+      Tea.destroy_all
+      Subscription.destroy_all
+      customer = Customer.create!(first_name: "Zac", last_name: "Hazelwood", email: "email@gmail.com", address: "123 Real St")
+      tea = Tea.create!(title: "Earl Grey", description: "A fine tea.", temperature: 120, brew_time: 2)
+      subscription = customer.subscriptions.create!(title: "Earl Grey Weekly", price: 19.99, tea_id: tea.id)
+
+      expect(subscription.status).to eq("active")
+      expect(subscription.frequency).to eq("weekly")
+
+      update_params =
+        {
+          subscription_id: subscription.id,
+          status: "cancelled"
+        }
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      patch "/api/v1/customers/#{customer.id}/subscriptions/#{subscription.id}", headers: headers, params: JSON.generate(update_params)
+
+      updated = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(response).to have_http_status(200)
+
+      expect(updated[:data][:attributes][:status]).to eq("cancelled")
+      expect(updated[:data][:attributes][:status]).to_not eq("active")
+    end
+
+    it "updates a subscription's status to 'active'"do
+      Customer.destroy_all
+      Tea.destroy_all
+      Subscription.destroy_all
+      customer = Customer.create!(first_name: "Zac", last_name: "Hazelwood", email: "email@gmail.com", address: "123 Real St")
+      tea = Tea.create!(title: "Earl Grey", description: "A fine tea.", temperature: 120, brew_time: 2)
+      subscription = customer.subscriptions.create!(title: "Earl Grey Monthly", price: 39.99, tea_id: tea.id, status: 1, frequency: 1)
+
+      expect(subscription.status).to eq("cancelled")
+      expect(subscription.frequency).to eq("monthly")
+
+      update_params =
+        {
+          subscription_id: subscription.id,
+          status: "active"
+        }
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      patch "/api/v1/customers/#{customer.id}/subscriptions/#{subscription.id}", headers: headers, params: JSON.generate(update_params)
+
+      updated = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(response).to have_http_status(200)
+
+      expect(updated[:data][:attributes][:status]).to eq("active")
+      expect(updated[:data][:attributes][:status]).to_not eq("cancelled")
+    end
+
+    it "updates other subscription parameters"do
+      Customer.destroy_all
+      Tea.destroy_all
+      Subscription.destroy_all
+      customer = Customer.create!(first_name: "Zac", last_name: "Hazelwood", email: "email@gmail.com", address: "123 Real St")
+      tea = Tea.create!(title: "Earl Grey", description: "A fine tea.", temperature: 120, brew_time: 2)
+      subscription = customer.subscriptions.create!(title: "Earl Grey Weekly", price: 19.99, tea_id: tea.id)
+
+      expect(subscription.title).to eq("Earl Grey Weekly")
+      expect(subscription.price).to eq(19.99)
+      expect(subscription.status).to eq("active")
+      expect(subscription.frequency).to eq("weekly")
+
+      update_params =
+        {
+          subscription_id: subscription.id,
+          title: "Earl Grey Monthly",
+          price: 39.99,
+          frequency: "monthly"
+        }
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      patch "/api/v1/customers/#{customer.id}/subscriptions/#{subscription.id}", headers: headers, params: JSON.generate(update_params)
+
+      updated = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(response).to have_http_status(200)
+
+      expect(updated[:data][:attributes][:status]).to eq("active")
+      expect(updated[:data][:attributes][:status]).to_not eq("cancelled")
+      expect(updated[:data][:attributes][:title]).to eq("Earl Grey Monthly")
+      expect(updated[:data][:attributes][:price]).to eq(39.99)
+      expect(updated[:data][:attributes][:frequency]).to eq("monthly")
+    end
+  end
+end


### PR DESCRIPTION
### Why is this PR necessary?
Subscription parameters can be updated by the Customer, as needed

## What does this PR do?
- Adds PATCH request, update, to Subscriptions to change subscription parameters
- Fixes Routes to reflect CRUD-function definition change
- Completes error handling for all requests

## Which User Story does this link to?
#7 & #10 
